### PR TITLE
fix: adjust link URL paths to make them work

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/conference/index.html
+++ b/docs/conference/index.html
@@ -18,6 +18,11 @@
 
     <script type="text/javascript" src="/assets/js/testing.js"></script>
 
+    <!-- Consolidate duplicate URLs: -->
+    <!-- - https://support.google.com/webmasters/answer/139066?hl=en  -->
+    <link rel="canonical" href="https://techexcellence.dev/conference/"
+
+
     <!-- common social tags -->
     <meta name="title" content="Tech Excellence Conference">
     <!-- OpenGraph http://ogp.me/ -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,11 @@
 
     <script type="text/javascript" src="/assets/js/testing.js"></script>
 
+    <!-- Consolidate duplicate URLs: -->
+    <!-- - https://support.google.com/webmasters/answer/139066?hl=en  -->
+    <link rel="canonical" href="https://techexcellence.dev/"
+
+
     <!-- common social tags -->
     <meta name="title" content="Tech Excellence events">
     <!-- OpenGraph http://ogp.me/ -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,10 +71,10 @@
       <section>
         <ul>
           <li>
-            <a href="conference.html">Tech Excellence Conference - Helsinki, Finland June 3rd</a>
+            <a href="/conference">Tech Excellence Conference - Helsinki, Finland June 3rd</a>
           </li>
           <li>
-            <a href="training.html">Tech Excellence Training - Event Storming with Tobias Goeschel May 27-28th</li>
+            <a href="/training">Tech Excellence Training - Event Storming with Tobias Goeschel May 27-28th</li>
             <li>
               <a href="https://www.meetup.com/Tech-Excellence-Finland/" rel="noopener noreferrer">Tech Excellence Finland Meetup</a>
             </li>

--- a/docs/training/index.html
+++ b/docs/training/index.html
@@ -18,6 +18,11 @@
 
     <script type="text/javascript" src="/assets/js/testing.js"></script>
 
+    <!-- Consolidate duplicate URLs: -->
+    <!-- - https://support.google.com/webmasters/answer/139066?hl=en  -->
+    <link rel="canonical" href="https://techexcellence.dev/training/"
+
+
     <!-- common social tags -->
     <meta name="title" content="Tech Excellence Training event">
     <!-- OpenGraph http://ogp.me/ -->


### PR DESCRIPTION
- Fix for the main page links.
- Improvement for reducing potential duplicate URL issues
- Improvement to the EditorConfig settings

# Changes

## fix: adjust link URL paths to make them work
- Adjust link URL paths to make them work on the new site structure

## fix: consolidate duplicate URLs with canonical URL metadata
- Consolidate duplicate URLs with canonical URL metadata

More details:
- https://support.google.com/webmasters/answer/139066?hl=en

## chore(.editorconfig): improve EditorConfig settings for Markdown files
- Improve EditorConfig settings for Markdown files
  - Disable trimming of the trailing whitespace for `*.md` files